### PR TITLE
DB-correct-status_id

### DIFF
--- a/db/migrate/20191124055407_remove_status_id_from_products.rb
+++ b/db/migrate/20191124055407_remove_status_id_from_products.rb
@@ -1,0 +1,5 @@
+class RemoveStatusIdFromProducts < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :products, :status_id, :BIGINT
+  end
+end

--- a/db/migrate/20191124055753_add_status_id_to_products.rb
+++ b/db/migrate/20191124055753_add_status_id_to_products.rb
@@ -1,0 +1,5 @@
+class AddStatusIdToProducts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :products, :status_id, :BIGINT, default:1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_18_080652) do
+ActiveRecord::Schema.define(version: 2019_11_24_055753) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture_id"
@@ -79,7 +79,6 @@ ActiveRecord::Schema.define(version: 2019_11_18_080652) do
     t.index ["brand_id"], name: "index_products_on_brand_id"
     t.index ["category_id"], name: "index_products_on_category_id"
     t.index ["size_id"], name: "index_products_on_size_id"
-    t.index ["status_id"], name: "index_products_on_status_id"
     t.index ["user_id"], name: "index_products_on_user_id"
   end
 
@@ -137,6 +136,5 @@ ActiveRecord::Schema.define(version: 2019_11_18_080652) do
   add_foreign_key "products", "brands"
   add_foreign_key "products", "categories"
   add_foreign_key "products", "sizes"
-  add_foreign_key "products", "statuses"
   add_foreign_key "products", "users"
 end


### PR DESCRIPTION
# What
DBを修正。
status_id に、default値:1 を追加

# Why
商品出品時に、status_id カラムに1を追加したいため。