### PR TITLE
Omniauth_registration_improvement

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -14,7 +14,8 @@ class SignupController < ApplicationController
   def user_registration2
     @user = User.new
     @user.build_myaddress
-    session["devise.facebook_data"].clear
+    session["devise.facebook_data"] = nil
+    session["devise.google_data"] = nil
 
     if verify_recaptcha # recaptcha（ロボット認証）
       render action: 'user_registration2' # trueなら次のページ

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -14,6 +14,7 @@ class SignupController < ApplicationController
   def user_registration2
     @user = User.new
     @user.build_myaddress
+    session["devise.facebook_data"].clear
 
     if verify_recaptcha # recaptcha（ロボット認証）
       render action: 'user_registration2' # trueなら次のページ

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -26,7 +26,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in_and_redirect @user, event: :authentication 
       set_flash_message(:notice, :success, kind: 'google') if is_navigational_format?
     else
-      session["devise.google_data"] = request.env["omniauth.auth"]
+      session["devise.google_data"] = request.env["omniauth.auth"][:info]
       redirect_to user_registration1_signup_index_url
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,6 +32,8 @@ class User < ApplicationRecord
         email: auth.info.email,
         password: Devise.friendly_token[0, 20],
         nickname: auth.info.name,
+        last_name: auth.info.last_name,
+        first_name: auth.info.first_name,
       )
       SnsCredential.new(
         provider: auth.provider,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,7 +54,7 @@ class User < ApplicationRecord
   validates :nickname, presence: true, length: { maximum: 20 }, on: :validates_step1
   validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX, message: 'は有効でありません。' }, on: :validates_step1
   validates :password, presence: true, length: { in: 7..255 }, format: { with: VALID_PASSWORD_REGEX, message: 'は255文字以下に設定して下さい'}, on: :validates_step1
-  validates :password_confirmation, presence: true, length: { in: 7..255 }, format: { with: VALID_PASSWORD_REGEX, message: 'は255文字以下に設定して下さい'}, on: :validates_step1
+  # validates :password_confirmation, presence: true, length: { in: 7..255 }, format: { with: VALID_PASSWORD_REGEX, message: 'は255文字以下に設定して下さい'}, on: :validates_step1
   validates :birthday, presence: true, on: :validates_step1
   validates :last_name, presence: true, length: { maximum: 20 }, on: :validates_step1
   validates :first_name, presence: true, length: { maximum: 20 }, on: :validates_step1

--- a/app/views/signup/user_registration1.html.haml
+++ b/app/views/signup/user_registration1.html.haml
@@ -40,7 +40,10 @@
               メールアドレス
             %span.signup-form1__span
               必須
-            = f.email_field :email, placeholder: 'PC・携帯どちらでも可', class: 'signup-form1__form validate[required] custom[email]'
+            -if session["devise.facebook_data"].present?
+              = f.email_field :email, placeholder: 'PC・携帯どちらでも可',value: "#{session["devise.facebook_data"]["info"]["email"]}", class: 'signup-form1__form validate[required] custom[email]'
+            - else
+              = f.email_field :email, placeholder: 'PC・携帯どちらでも可', class: 'signup-form1__form validate[required] custom[email]'
           .signup-form1
             %label.signup-form1__label
               パスワード

--- a/app/views/signup/user_registration1.html.haml
+++ b/app/views/signup/user_registration1.html.haml
@@ -67,12 +67,12 @@
                 お名前(全角)
               %span.signup-form1__span
                 必須
-              - if session["devise.google_data"].present?
-                = f.text_field :last_name, placeholder: '例) 山田', value: "#{session["devise.google_data"]["last_name"]}", class: 'signup-form1__last-name validate[required]'
-                = f.text_field :first_name, placeholder: '例) 彩', value: "#{session["devise.google_data"]["first_name"]}", class: 'signup-form1__first-name validate[required]'
-              - else
-                = f.text_field :last_name, placeholder: '例) 山田', class: 'signup-form1__last-name validate[required]'
-                = f.text_field :first_name, placeholder: '例) 彩', class: 'signup-form1__first-name validate[required]'
+            - if session["devise.google_data"].present?
+              = f.text_field :last_name, placeholder: '例) 山田', value: "#{session["devise.google_data"]["last_name"]}", class: 'signup-form1__last-name validate[required]'
+              = f.text_field :first_name, placeholder: '例) 彩', value: "#{session["devise.google_data"]["first_name"]}", class: 'signup-form1__first-name validate[required]'
+            - else
+              = f.text_field :last_name, placeholder: '例) 山田', class: 'signup-form1__last-name validate[required]'
+              = f.text_field :first_name, placeholder: '例) 彩', class: 'signup-form1__first-name validate[required]'
           .signup-form1
             .signup-form1-fullname
               %label.signup-form1__label

--- a/app/views/signup/user_registration1.html.haml
+++ b/app/views/signup/user_registration1.html.haml
@@ -40,8 +40,10 @@
               メールアドレス
             %span.signup-form1__span
               必須
-            -if session["devise.facebook_data"].present?
+            - if session["devise.facebook_data"].present?
               = f.email_field :email, placeholder: 'PC・携帯どちらでも可',value: "#{session["devise.facebook_data"]["info"]["email"]}", class: 'signup-form1__form validate[required] custom[email]'
+            - elsif session["devise.google_data"].present?
+              = f.email_field :email, placeholder: 'PC・携帯どちらでも可',value: "#{session["devise.google_data"]["email"]}", class: 'signup-form1__form validate[required] custom[email]'
             - else
               = f.email_field :email, placeholder: 'PC・携帯どちらでも可', class: 'signup-form1__form validate[required] custom[email]'
           .signup-form1
@@ -65,8 +67,12 @@
                 お名前(全角)
               %span.signup-form1__span
                 必須
-            = f.text_field :last_name, placeholder: '例) 山田', class: 'signup-form1__last-name validate[required]'
-            = f.text_field :first_name, placeholder: '例) 彩', class: 'signup-form1__first-name validate[required]'
+              - if session["devise.google_data"].present?
+                = f.text_field :last_name, placeholder: '例) 山田', value: "#{session["devise.google_data"]["last_name"]}", class: 'signup-form1__last-name validate[required]'
+                = f.text_field :first_name, placeholder: '例) 彩', value: "#{session["devise.google_data"]["first_name"]}", class: 'signup-form1__first-name validate[required]'
+              - else
+                = f.text_field :last_name, placeholder: '例) 山田', class: 'signup-form1__last-name validate[required]'
+                = f.text_field :first_name, placeholder: '例) 彩', class: 'signup-form1__first-name validate[required]'
           .signup-form1
             .signup-form1-fullname
               %label.signup-form1__label


### PR DESCRIPTION
# what
  Omniauth認証に関して、
  sessionを使用し
  認可サーバーから来た情報（ユーザー名、emailアドレス）を、予め新規登録フォームに入力しておくように仕様変更した。

# why
　ユーザーの使用勝手の向上のため。