### PR TITLE
商品出品ページのカテゴリ、サイズ用プルダウン作成（孫・サイズ）

### DIFF
--- a/app/assets/javascripts/exhibit.js
+++ b/app/assets/javascripts/exhibit.js
@@ -1,4 +1,4 @@
-$(function() {
+$(function(){
   
   $(function(){
     var maxNum = 1000000; // 注文できる金額の上限
@@ -22,10 +22,9 @@ $(function() {
         var price = '¥' + p;
         tagOutput.html(price);
       } 
-    
-      
       });
     });
+
   $(function(){
     var maxNum = 1000000; // 注文できる金額の上限
     var tagInput = $('#pricebox'); // 入力対象のinputタグID名
@@ -139,6 +138,11 @@ $(function(){
 
 
 $(function(){
+  $('#product_child_id').hide();
+  $('#product_category_id').hide();
+  $('.exhibitmain__details__size-name').hide();
+  $('#product_size_id').hide();
+  $('#product_parent_id').prepend('<option value="0">---</option>');
   $('#product_parent_id').change(function() {
     var parent_id = $('#product_parent_id').val();
     $.ajax({
@@ -150,6 +154,12 @@ $(function(){
     .done(function(data){
       var obj = data;
       $('#product_child_id').html("");
+      $('.exhibitmain__details__size-name').hide();
+      $('#product_size_id').hide();
+      $('#product_size_id').val('');
+      $('#product_category_id').hide();
+      $('#product_child_id').show();
+      $('#product_child_id').append('<option value="0">---</option>');
       for(var i=0;i<obj.length;i++){
         $('#product_child_id').append("<option value=" + obj[i].id+">"+obj[i].name+"</option>");
       }
@@ -160,27 +170,55 @@ $(function(){
     })
   });
   //孫カテゴリー実装のための記述 村上191127
-  // $('#product_child_id').change(function() {
-  //   var child_id = $('#product_child_id').val();
-  //   $.ajax({
-  //     type: 'POST',
-  //     url: '../api/products',
-  //     data: {id : child_id},
-  //     dataType: 'json',
-  //     // contentType: false,
-  //     // processData: false,
-  //   })
-  //   .done(function(data){
-  //     // var html = child_category(data);
-  //     var obj2 = data;
-  //     $('#product_category_id').html("");
-  //     for(var i=0;i<obj.length;i++){
-  //       $('#product_category_id').append("<option value=" + obj2[i].id+">"+obj2[i].name+"</option>");
-  //     }
+  $('#product_child_id').change(function() {
+    var child_id = $('#product_child_id').val();
+    $.ajax({
+      type: 'POST',
+      url: '../api/products2',
+      data: {id : child_id},
+      dataType: 'json',
+      // contentType: false,
+      // processData: false,
+    })
+    .done(function(data){
+      var obj2 = data;
+      $('#product_category_id').html("");
+      $('.exhibitmain__details__size-name').hide();
+      $('#product_size_id').hide();
+      $('#product_size_id').val('');
+      $('#product_category_id').show();
+      $('#product_category_id').append('<option value="0">---</option>');
+      for(var i=0;i<obj2.length;i++){
+        $('#product_category_id').append("<option value=" + obj2[i].id+">"+obj2[i].name+"</option>");
+      }
+    })
+    .fail(function(){
+      alert('error');
+    })
+  })
+    $('#product_category_id').change(function() {
+      var grandchild_id = $('#product_category_id').val();
+      $.ajax({
+        type: 'POST',
+        url: '../api/products3',
+        data: {id : grandchild_id},
+        dataType: 'json',
+        // contentType: false,
+        // processData: false,
+      })
+      .done(function(data){
+        var obj3 = data;
+        $('#product_size_id').html("");
+        $('.exhibitmain__details__size-name').show();
+        $('#product_size_id').show();
+        $('#product_size_id').append('<option value="0">---</option>');
+        for(var i=0;i<obj3.length;i++){
+          $('#product_size_id').append("<option value=" + obj3[i].id+">"+obj3[i].name+"</option>");
+        }
+      })
+      .fail(function(){
+        alert('error');
+      });
+    });
 
-  //   })
-  //   .fail(function(){
-  //     alert('error');
-  //   })
-  // });
 })

--- a/app/assets/javascripts/exhibit.js
+++ b/app/assets/javascripts/exhibit.js
@@ -142,7 +142,6 @@ $(function(){
   $('#product_category_id').hide();
   $('.exhibitmain__details__size-name').hide();
   $('#product_size_id').hide();
-  $('#product_parent_id').prepend('<option value="0">---</option>');
   $('#product_parent_id').change(function() {
     var parent_id = $('#product_parent_id').val();
     $.ajax({

--- a/app/assets/stylesheets/products/_exhibit.scss
+++ b/app/assets/stylesheets/products/_exhibit.scss
@@ -136,9 +136,11 @@
   &__size-name{
     @include title;
     text-indent: 220px;
+    margin-top: 15px;
   }
   span {
     @include need;
+    margin-top: 15px;
    }
   &__size-box{
     padding-left: 217px;

--- a/app/controllers/api/products2_controller.rb
+++ b/app/controllers/api/products2_controller.rb
@@ -1,0 +1,6 @@
+class Api::Products2Controller < ApplicationController
+  def create
+    children = Category.find(params[:id])
+    @grandchildren = children.children
+  end
+end

--- a/app/controllers/api/products3_controller.rb
+++ b/app/controllers/api/products3_controller.rb
@@ -1,0 +1,9 @@
+class Api::Products3Controller < ApplicationController
+
+  def create
+    grandchild = Category.find(params[:id])
+    size_tag = grandchild.size_tag
+    @choices_for_size = Size.where(size_tag: size_tag)
+  end
+
+end

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -1,6 +1,9 @@
 class Api::ProductsController < ApplicationController
+
   def create
-    @parent = Category.find(params[:id])
-    @children = @parent.children
+    parent = Category.find(params[:id])
+    @children = parent.children
   end
+
 end
+

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -24,7 +24,9 @@ class ProductsController < ApplicationController
   def new
     @product = Product.new
     @product.images.build
-    @parent = Category.where(id: 1..13)
+    # @parent = Category.where(id: 1..13)
+    # 平野テストのため、idの値を一時的に変更しています・・・
+    @parent = Category.where(id: 3927..3939)
   end
 
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -24,9 +24,9 @@ class ProductsController < ApplicationController
   def new
     @product = Product.new
     @product.images.build
-    # @parent = Category.where(id: 1..13)
-    # 平野テストのため、idの値を一時的に変更しています・・・
-    @parent = Category.where(id: 3927..3939)
+    @parent = Category.where(id: 1..13)
+    # 平野テスト用コード、idの値を一時的に変更しています・・・後ほど修正予定
+    # @parent = Category.where(id: 3927..3939)
   end
 
 

--- a/app/views/api/products2/create.json.jbuilder
+++ b/app/views/api/products2/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @grandchildren do |grandchildren|
+  json.id grandchildren.id
+  json.name grandchildren.name
+end

--- a/app/views/api/products3/create.json.jbuilder
+++ b/app/views/api/products3/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @choices_for_size do |choices_for_size|
+  json.id choices_for_size.id
+  json.name choices_for_size.size_name
+end

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -43,7 +43,7 @@
           サイズ
           %span 必須
         .exhibitmain__details__size-box 
-          = f.select :size_id, [["---", 0],["LL", 1],["L", 2]] 
+          = f.select :size_id, {}
         .exhibitmain__details__brand-name
           ブランド
           %span.span1 任意

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,7 +59,10 @@ Rails.application.routes.draw do
   end
 
   namespace :api do
-    resources :products, only: :create ,defaults: { format: 'json'}
+    resources :products, only: :create, defaults: { format: 'json'}
+    resources :products2, only: :create, defaults: { format: 'json'}
+    resources :products3, only: :create, defaults: { format: 'json'}
   end 
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
# what
　・商品出品ページの孫カテゴリ、サイズ入力用プルダウンのjs作成
      (ajax通信含む）（サイズ欄の表示条件は未実装）

# why
　・選択肢に合わせて、カテゴリの子/孫要素、サイズの表示を条件分岐させるため。

実際の動画
https://gyazo.com/9c4f32561cdff519405feb30fb3dea81