### PR TITLE
change_show_method_of_size

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -106,5 +106,8 @@ class ProductsController < ApplicationController
 
   def set_product
     @product = Product.find(params[:id])
+    if @product.size_id.present?
+      @size = Size.find(@product.size_id)
+    end
   end
 end

--- a/app/views/users/section/_mypage-change.html.haml
+++ b/app/views/users/section/_mypage-change.html.haml
@@ -53,7 +53,7 @@
             %th 商品のサイズ
             %td
               %span 
-                = @product.size
+                = @size.size_name
           %tr
             %th 商品の状態
             %td


### PR DESCRIPTION
# what
 商品詳細ページ　、my商品詳細ページ（+my商品編集ページ）のsizeの表示方法の変更

# why
 productテーブルのsize_idカラムのnull許可のため、productテーブルとsizeテーブル間のアソシエーションを切ったことに伴う変更。発見が遅れて大変申し訳ございませんでした！！