### PR TITLE
size display change

### DIFF
--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -54,7 +54,8 @@
             %th 商品のサイズ
             %td
               %span 
-                M
+                - if @size.present?
+                  = @size.size_name
           %tr
             %th 商品の状態
             %td

--- a/app/views/users/section/_mypage-change.html.haml
+++ b/app/views/users/section/_mypage-change.html.haml
@@ -53,7 +53,8 @@
             %th 商品のサイズ
             %td
               %span 
-                = @size.size_name
+                - if @size.present?
+                  = @size.size_name
           %tr
             %th 商品の状態
             %td

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,7 +11,6 @@ FactoryBot.define do
     birthday              {"1994-04-01"}
     tel                   {"09012345678"}
     self_introduction     {"よろしく"}
-    money                 {"10000"}
     point                 {"111111"}
     zip                   {"1111111"}
     prefecture            {"大阪府"}


### PR DESCRIPTION
# what
 　サイズ表示方法の変更
　factory botの改定

# why
　sizeを持たない商品の場合のエラーを防ぐため。
　user/moneyカラムを消したことに伴って。
　