### PR TITLE
html_lang=ja

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,5 +1,5 @@
 !!!
-%html
+%html{lang: "ja"}
   %head
     %meta{content: "text/html: charset=UTF-8", "http-equiv": "Content-Type"}/
     %title FREEMARKET

--- a/app/views/users/section/_user-confirmation.html.haml
+++ b/app/views/users/section/_user-confirmation.html.haml
@@ -30,7 +30,7 @@
         %span.user-confirmation-form1__span
           必須
         .prefecture-select-wrap
-          = f.collection_select :prefecture, Prefecture.all, :id, :name, { prompt:"---" }
+          = f.collection_select :prefecture, Prefecture.all, :id, :name
       .user-confirmation-form2
         %label.user-confirmation-form1__label
           市区町村


### PR DESCRIPTION
# What
①application.html.hamlに日本語ページ ということを明示的に記述
②住所編集（都道府県）のセレクタを編集

# Why
①新規登録（お届け先住所）の際、翻訳機能が作動してしまう為
②”---”が二つある為