### PR TITLE
 Restriction_correction

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -46,8 +46,8 @@ class ProductsController < ApplicationController
   end
 
   def edit
-      gon.product_price = @product.price
-      gon.all_point = current_user.point
+    gon.product_price = @product.price
+    gon.all_point = current_user.point
   end
 
   def sell_edit
@@ -128,7 +128,7 @@ class ProductsController < ApplicationController
   end
 
   def ensure_correct_product
-    @product = Product.find_by(id: params[:id])
+    @product = Product.find(params[:id])
     redirect_to root_path if current_user.id !=  @product.user_id
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,7 +2,7 @@ class ProductsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :change, :destroy, :edit]
   before_action :set_product, only: [:destroy, :change, :show, :edit, :ensure_correct_product]
   before_action :set_category, only: [:show, :change]
-  before_action :ensure_correct_product, only: [:change]
+  before_action :ensure_correct_product, except: [:index, :new, :show, :edit, :create]
 
 
   def index
@@ -46,8 +46,8 @@ class ProductsController < ApplicationController
   end
 
   def edit
-    gon.product_price = @product.price
-    gon.all_point = current_user.point
+      gon.product_price = @product.price
+      gon.all_point = current_user.point
   end
 
   def sell_edit
@@ -66,9 +66,6 @@ class ProductsController < ApplicationController
     end
   end
 
-
-
-  
   def create
     @product = Product.new(product_params)
     # @product = current_user.products.build(product_params)
@@ -93,18 +90,6 @@ class ProductsController < ApplicationController
       redirect_to root_path
     end
   end
-
-
-  def change
-  end
-
-  def ensure_correct_product
-
-    redirect_to root_path if current_user.id !=  @product.user_id
-
-  end
-
-
 
   # 以下、仮に人気カテゴリー、人気ブランドをリアルタイム対応させる場合の記述。
   # productテーブルにcategory_idカラムとbrand_idカラムを追加した後に実装予定
@@ -141,4 +126,10 @@ class ProductsController < ApplicationController
     @child = @grandchild.parent
     @parent = @child.parent
   end
+
+  def ensure_correct_product
+    @product = Product.find_by(id: params[:id])
+    redirect_to root_path if current_user.id !=  @product.user_id
+  end
+
 end

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -1,5 +1,6 @@
 class PurchaseController < ApplicationController
   before_action :set_product, only: [:index, :pay]
+  before_action :user_restriction, except: [:done]
   require 'payjp'
 
   def index
@@ -22,8 +23,8 @@ class PurchaseController < ApplicationController
       customer: card.customer_id,
       currency: :'jpy',
     )
-    @product.status_id = 3
-    if @product.save
+    @product.update(status_id: 3)
+    if @product.save(validate: false)
       redirect_to action: 'done'
     else
       flash[:notice] = '問題が発生して処理を中止しました。'
@@ -40,4 +41,9 @@ class PurchaseController < ApplicationController
   def set_product
     @product = Product.find_by(id: params[:product_id])
   end
+
+  def user_restriction
+    redirect_to root_path if current_user.id == @product.user_id
+  end
+
 end

--- a/app/views/users/section/_mypage-change.html.haml
+++ b/app/views/users/section/_mypage-change.html.haml
@@ -90,7 +90,7 @@
         = @product.description
   .itembuy-content__change-status
     .itembuy-content__change-status-btns
-      = link_to '商品の編集', myedit_user_path, class: 'itembuy-red-box' 
+      = link_to '商品の編集', myedit_users_path, class: 'itembuy-red-box' 
     .itembuy-content__text-center
       or
     .itembuy-content__change-status-btns

--- a/app/views/users/section/_mypage-left.html.haml
+++ b/app/views/users/section/_mypage-left.html.haml
@@ -20,7 +20,7 @@
       .select-icon-space
         = fa_icon 'angle-right', class: 'select-icon i4'
   .main__left-list
-    =link_to new_product_path(@user), class: "main__left-list__nav btn space-5" do
+    =link_to new_product_path, class: "main__left-list__nav btn space-5" do
       出品する
       .select-icon-space
         = fa_icon 'angle-right', class: 'select-icon i5'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,9 +24,9 @@ Rails.application.routes.draw do
       get '/products/:id', to: "products#change", as: :users_myproduct_change #要検討20191125
       delete '/products/:id', to: "products#destroy"
       patch '/products/:id', to: "products#update"
+      get '/products/:id/edit', to: "products#sell_edit", as: :myedit
     end
     member do
-      get '/products/:id/edit', to: "products#sell_edit", as: :myedit
       get 'logout'
       get 'profile'
       get 'credit_add'


### PR DESCRIPTION
# What
①商品編集・削除等の制限追加（ensure_correct_product）
②商品購入時、出品者の場合の制限追加（user_restriction）
③本番環境で購入時にproductのstatus_idを”3”にセーブできなかった為、編集（validate: false）
④product/sell_editのルーティング修正（memberからcorrectionに）

# Why（trelloサーバーサイド確認点）
①他人の商品の編集画面へ飛べないようになっている
①他人の商品の更新アクション(products#update)を動かせないようになっている
①他人の商品の削除アクション(products#destroy)を動かせないようになっている
②出品した本人が自身の商品の支払い作成アクション(Payjp::Charge.createを実行するアクション)を動かせ
　ないようになっている
②出品した本人が自身の商品の購入画面へURLを直打ちしても飛べないようになっている
③商品購入時に、statu_idが変化し購入済扱いになる

済：ログインしていないユーザーが商品一覧・商品詳細以外のページへ行こうとしたらログインページへリダイレクトさせる