### PR TITLE
エラー修正

### DIFF
--- a/app/assets/javascripts/sell_edit.js
+++ b/app/assets/javascripts/sell_edit.js
@@ -2,6 +2,7 @@ $(function(){
   if ( gon.selected_size == null ){
     $('.exhibitmain__details__size-name').hide();
     $('#product_size_id').hide();
+    $('#product_size_id').html("");
   }
   var current_delivery_charged_status = $('.exhibitmain__delivery__burden__box1').val();
   if ( current_delivery_charged_status == "shipping_fee_on_shipper"){
@@ -225,7 +226,12 @@ $(function(){
         for(var i=0;i<obj3.length;i++){
           $('#product_size_id').append("<option value=" + obj3[i].id+">"+obj3[i].name+"</option>");
         }
-       }
+      }
+        else if(data.length == 0 ){
+          $('.exhibitmain__details__size-name').hide();
+          $('#product_size_id').hide();
+          $('#product_size_id').val('');
+        }
       })
       .fail(function(){
         alert('error');

--- a/app/assets/javascripts/sell_edit.js
+++ b/app/assets/javascripts/sell_edit.js
@@ -1,5 +1,17 @@
 $(function(){
-  
+  if ( gon.selected_size == null ){
+    $('.exhibitmain__details__size-name').hide();
+    $('#product_size_id').hide();
+  }
+  var current_delivery_charged_status = $('.exhibitmain__delivery__burden__box1').val();
+  if ( current_delivery_charged_status == "shipping_fee_on_shipper"){
+    $('.exhibitmain__delivery__way-box1').children('option[value="rakuraku_mercari_bin"]').remove();
+    $('.exhibitmain__delivery__way-box1').children('option[value="letter_pack"]').remove();
+    $('.exhibitmain__delivery__way-box1').children('option[value="normal"]').remove();
+    $('.exhibitmain__delivery__way-box1').children('option[value="clickpost"]').remove();
+  }
+
+
   $(function(){
     var maxNum = 1000000; // 注文できる金額の上限
     var tagInput = $('#pricebox'); // 入力対象のinputタグID名
@@ -82,8 +94,8 @@ $(function(){
 
   // 配送方法のJSの実装
   $('.exhibitmain__delivery__burden__box1').change(function() {
-      var a = $('.exhibitmain__delivery__burden__box1').val();
-      if(a == "---") {
+      var delivery_charged_status = $('.exhibitmain__delivery__burden__box1').val();
+      if(delivery_charged_status == "---") {
           $('.exhibitmain__delivery__way').hide();
           $('.exhibitmain__delivery__way-box').hide();
           $('.exhibitmain__delivery__way-box1').children('option[value="rakuraku_mercari_bin"]').remove();
@@ -93,7 +105,7 @@ $(function(){
           // 下記コメントは念のため記載しております 191125 髙橋
           // $('.exhibitmain__delivery__way2').hide();
           // $('.exhibitmain__delivery__way-box2').hide();
-      }else if(a == "shipping_fee_on_shipper") {
+      }else if(delivery_charged_status == "shipping_fee_on_shipper") {
           $('.exhibitmain__delivery__way-box1').val('0');
           $('.exhibitmain__delivery__way').show();
           $('.exhibitmain__delivery__way-box').show();
@@ -104,7 +116,7 @@ $(function(){
           // 下記コメントは念のため記載しております 191125 髙橋
           // $('.exhibitmain__delivery__way2').hide();
           // $('.exhibitmain__delivery__way-box2').hide();
-      }else if(a == "shipping_fee_on_receiver") {
+      }else if(delivery_charged_status == "shipping_fee_on_receiver") {
           $('.exhibitmain__delivery__way-box1').val('0');
           $('.exhibitmain__delivery__way').show();
           $('.exhibitmain__delivery__way-box').show();
@@ -139,10 +151,7 @@ $(function(){
 
 $(function(){
   //  $('#product_size_id').hide();
-  if ( gon.selected_size == null ){
-    $('.exhibitmain__details__size-name').hide();
-    $('#product_size_id').hide();
-  }
+  
   $('#product_parent_id').change(function() {
     var parent_id = $('#product_parent_id').val();
     $.ajax({

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -4,6 +4,8 @@ class ProductsController < ApplicationController
   before_action :set_category, only: [:show, :change]
   before_action :ensure_correct_product, except: [:index, :new, :show, :edit, :create]
   before_action :set_image, only: [:show, :change]
+  before_action :set_current_category_group, only: :sell_edit
+  before_action :set_current_size_for_sell_edit, only: :sell_edit
 
 
   def index
@@ -53,19 +55,12 @@ class ProductsController < ApplicationController
 
   def sell_edit
     @parent_group = Category.where(id: 1..13)
-    @selected_grandson_category = Category.find(@product.category_id)
-    @grandchild_group = @selected_grandson_category.siblings
-    @selected_child_category = @selected_grandson_category.parent
-    @child_group = @selected_child_category.siblings
-    @size_tag_group = Size.where(size_tag: @size.size_tag)
-    gon.selected_size = @size
     @product_fee = (@product.price * 0.1).round
     @product_profit = (@product.price * 0.9).round
   end
 
   def update 
     @product = Product.find(params[:id])
-
     if @product.update(product_params) 
       @product.images[0].destroy
       redirect_to root_path
@@ -141,6 +136,28 @@ class ProductsController < ApplicationController
   def ensure_correct_product
     @product = Product.find(params[:id])
     redirect_to root_path if current_user.id !=  @product.user_id
+  end
+
+  def set_current_category_group
+    @selected_grandson_category = Category.find(@product.category_id)
+    @grandchild_group = @selected_grandson_category.siblings
+    @selected_child_category = @selected_grandson_category.parent
+    @child_group = @selected_child_category.siblings
+  end
+
+  def set_current_size_for_sell_edit
+    if @size.present?
+      gon.selected_size = @size
+      if @size.size_tag.present?
+        @size_tag_group = Size.where(size_tag: @size.size_tag)
+      elsif
+        @size_tag_group = Size.where(id: 1..2)
+      end
+    elsif
+      @size = Size.find(1)
+      @size_tag_group = Size.where(id: 1..2)
+      gon.selected_size = nil
+    end
   end
 
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -138,8 +138,9 @@ class ProductsController < ApplicationController
 
   def set_current_category_group
     @selected_grandson_category = Category.find(@product.category_id)
-    @grandchild_group = @selected_grandson_category.siblings
     @selected_child_category = @selected_grandson_category.parent
+    @selected_parent_category = @selected_child_category.parent
+    @grandchild_group = @selected_grandson_category.siblings
     @child_group = @selected_child_category.siblings
   end
 

--- a/app/views/products/sell_edit.html.haml
+++ b/app/views/products/sell_edit.html.haml
@@ -45,6 +45,7 @@
           サイズ
           %span 必須
         .exhibitmain__details__size-box 
+          -# エラー出るかも？
           = f.collection_select :size_id, @size_tag_group.all, :id, :size_name, selected: "#{@size.id}"
         .exhibitmain__details__brand-name
           ブランド

--- a/app/views/products/sell_edit.html.haml
+++ b/app/views/products/sell_edit.html.haml
@@ -45,7 +45,6 @@
           サイズ
           %span 必須
         .exhibitmain__details__size-box 
-          -# エラー出るかも？
           = f.collection_select :size_id, @size_tag_group.all, :id, :size_name, selected: "#{@size.id}"
         .exhibitmain__details__brand-name
           ブランド
@@ -65,13 +64,11 @@
           %span 必須 
         .exhibitmain__delivery__burden__box
           = f.select :delivery_charged, Product.delivery_chargeds.keys.map {|k| [I18n.t("enums.product.delivery_charged.#{k}"), k]}, {}, class: 'exhibitmain__delivery__burden__box1'
-          -# = f.select :delivery_charged, [["---", 0],[ "送料込み（出品者負担）", 1 ],["着払い（購入者負担）", 2] ], {}, class: 'exhibitmain__delivery__burden__box1'
         .exhibitmain__delivery__way
           配送方法
           %span 必須 
         .exhibitmain__delivery__way-box
           = f.select :delivery_way, Product.delivery_ways.keys.map {|k| [I18n.t("enums.product.delivery_way.#{k}"), k]}, {}, class: 'exhibitmain__delivery__way-box1'
-          -# = f.select :delivery_way, [["---", 0],["クロネコヤマト", 1],["ゆうパック", 2],["ゆうメール", 3]], {}, class: 'exhibitmain__delivery__way-box1'
         .exhibitmain__delivery__area
           配送元の地域
           %span 必須 
@@ -82,7 +79,6 @@
           %span 必須
         .exhibitmain__delivery__days-box
           = f.select :delivery_days,Product.delivery_days.keys.map {|k| [I18n.t("enums.product.delivery_days.#{k}"), k]} 
-          -# = f.select :delivery_days,[["---", 0],["1日~2日で発送", 1],["2日~3日で発送", 2],["4日~7日で発送"]] 
       .exhibitmain__price
         .exhibitmain__price__name
           販売価格(300~9,999,999)

--- a/app/views/products/sell_edit.html.haml
+++ b/app/views/products/sell_edit.html.haml
@@ -36,9 +36,7 @@
           カテゴリー
           %span 必須
         .exhibitmain__details__category-box1  
-          = f.collection_select :parent_id, @parent_group.all, :id, :name, class: "parent_category", name: "parent_box", selected: "#{@product.category_id}"
-            
-          
+          = f.collection_select :parent_id, @parent_group.all, :id, :name, class: "parent_category", name: "parent_box", selected: "#{@selected_parent_category.id}"
         .exhibitmain__details__category-box2
           = f.collection_select :child_id, @child_group.all, :id, :name, class: "child_category", selected: "#{@selected_child_category.id}"
         .exhibitmain__details__category-box3


### PR DESCRIPTION
# what
　・size_id, size_tagがない場合に、ダミーデータをビューに送信するように変更（POST前に消去, jsもそのパターンに対応するように追記）
　・sell_edit.jsの変数の名称を変更
　・productコントローラーのメソッドの切り分け


# why
・size_id, size_tagがない場合に、ビューが表示できないエラーを修正するため
・変数の意味をわかりやすくするため
・可読性の向上